### PR TITLE
fix inserts of multiple children

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -369,8 +369,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                     //     expression += subQuery;
 
                     } else if (column.isDiscriminator) {
-                        this.expressionMap.nativeParameters["discriminator_value"] = this.expressionMap.mainAlias!.metadata.discriminatorValue;
-                        expression += this.connection.driver.createParameter("discriminator_value", parametersCount);
+                        this.expressionMap.nativeParameters["discriminator_value" + parametersCount] = this.expressionMap.mainAlias!.metadata.discriminatorValue;
+                        expression += this.connection.driver.createParameter("discriminator_value" + parametersCount, parametersCount);
                         parametersCount++;
                         // return "1";
 


### PR DESCRIPTION
When we insert multiple child objects simultaneously, typeorm fails to include the discriminator column for all but the first of those objects.  This commit removes the assumption that there is a single discriminator column per insert.