### PR TITLE
adds an option to control whether columns are inserted by default

### DIFF
--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -48,6 +48,12 @@ export interface ColumnOptions extends ColumnCommonOptions {
     select?: boolean;
 
     /**
+     * Indicates if column is inserted by default.
+     * Default value is "true".
+     */
+    insert?: boolean;
+
+    /**
      * Default database value.
      */
     default?: any;

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -96,6 +96,11 @@ export class ColumnMetadata {
     isSelect: boolean = true;
 
     /**
+     * Indicates if column is inserted by default or not.
+     */
+    isInsert: boolean = true;
+
+    /**
      * Indicates if column is protected from updates or not.
      */
     isReadonly: boolean = false;
@@ -333,6 +338,8 @@ export class ColumnMetadata {
             this.isNullable = options.args.options.nullable;
         if (options.args.options.select !== undefined)
             this.isSelect = options.args.options.select;
+        if (options.args.options.insert !== undefined)
+            this.isInsert = options.args.options.insert;
         if (options.args.options.readonly !== undefined)
             this.isReadonly = options.args.options.readonly;
         if (options.args.options.comment)

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -337,6 +337,9 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
             if (this.expressionMap.insertColumns.length)
                 return this.expressionMap.insertColumns.indexOf(column.propertyPath) !== -1;
 
+            // skip columns the user doesn't want included by default, but rather only when explicitly set
+            if (!column.isInsert) { return false; }
+
             // if user did not specified such list then return all columns except auto-increment one
             // for Oracle we return auto-increment column as well because Oracle does not support DEFAULT VALUES expression
             if (column.isGenerated && column.generationStrategy === "increment" && !(this.connection.driver instanceof OracleDriver) && !(this.connection.driver instanceof MysqlDriver))


### PR DESCRIPTION
This adds an `insert` option, analogous to the existing `select`
option, for use in the `Column` decorator.  Just like a column
specified with `@Column({select: false})` will not be selected by
default in queries, a column specified with `@Column({insert: false})`
will not be inserted by default in `INSERT`s.

This is the simplest intervention I could think of to allow for
propagating computed columns to typeorm entities.  Now, a column
can be specified as `@Column({insert: false, select: false})`
and if a query computes the column it will be preserved in
typeorm entities.  There are a lot of issues filed looking for similar
behavior, and it is on the roadmap, so at some point there may
be official typeorm support for something like this.